### PR TITLE
return search items instead of fuse results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reaviz/react-use-fuzzy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React hook for client side fuzzy search using Fuse.js",
   "homepage": "https://github.com/reaviz/react-use-fuzzy#readme",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,9 @@ export function useFuzzy<T>(
     const defaultOptions = { tokenize: true, threshold: 0.2 };
     return new Fuse(data, { ...defaultOptions, ...options });
   }, [data, options]);
-  const result: T[] = keyword ? (searcher.search(keyword) as unknown as T[]) : data;
+  const result: T[] = keyword
+    ? (searcher.search(keyword) || []).map(r => r.item)
+    : data;
 
   return {
     keyword,


### PR DESCRIPTION
when react-use-fuzzy was using fuse.js version 3.x the search results were a list of the original items. When upgrading fuse.js to version 6.x, search results were of type Fuse.FuseResult which contain
```
{
  item,
  refIndex
}
```

to properly handle existing use of react-use-fuzzy, this PR returns a list of matching items instead of the new FuseResults